### PR TITLE
Re-add modified column to migration table.

### DIFF
--- a/dkan_migrate_base.install
+++ b/dkan_migrate_base.install
@@ -34,7 +34,7 @@ function dkan_migrate_base_disable() {
  */
 function _dkan_migrate_base_data_json_table($migration) {
   $map = new MigrateSQLMap(
-    'datajson_dataset_base',
+    $migration,
     array(
       'uuid' => array(
         'type' => 'varchar',

--- a/dkan_migrate_base.install
+++ b/dkan_migrate_base.install
@@ -8,13 +8,33 @@
  * Implements hook_install().
  */
 function dkan_migrate_base_install() {
-  // Ensure that map table is present before adding modifed column.
-  $migration = new MigrateDataJsonDatasetBase(array(
-    'group_name' => 'dkan',
-    'title' => t('Data.json Dataset Base'),
-  ));
+  $table = _dkan_migrate_base_data_json_table();
+  dkan_migrate_base_add_modified_column($table);
+}
+
+/**
+ * Implements hook_enable().
+ */
+function dkan_migrate_base_enable() {
+  dkan_migrate_base_migrations_enable();
+
+  $table = _dkan_migrate_base_data_json_table('datajson_dataset_base');
+  dkan_migrate_base_add_modified_column($table);
+}
+
+/**
+ * Implements hook_disable().
+ */
+function dkan_migrate_base_disable() {
+  dkan_migrate_base_migrations_disable();
+}
+
+/**
+ * Gets migration table name.
+ */
+function _dkan_migrate_base_data_json_table($migration) {
   $map = new MigrateSQLMap(
-    $migration->machine_name,
+    'datajson_dataset_base',
     array(
       'uuid' => array(
         'type' => 'varchar',
@@ -25,13 +45,5 @@ function dkan_migrate_base_install() {
     ),
     MigrateDestinationNode::getKeySchema()
   );
-  $table = $map->getMapTable();
-  dkan_migrate_base_add_modified_column($table);
-}
-
-/**
- * Implements hook_disable().
- */
-function dkan_migrate_base_disable() {
-  dkan_migrate_base_migrations_disable();
+  return $map->getMapTable();
 }

--- a/dkan_migrate_base.module
+++ b/dkan_migrate_base.module
@@ -16,6 +16,16 @@ function dkan_migrate_base_migrations_disable() {
 }
 
 /**
+ * Registers DKAN migrations.
+ */
+function dkan_migrate_base_migrations_enable() {
+  Migration::registerMigration('ckan_dataset_base');
+  Migration::registerMigration('ckan_group_base');
+  Migration::registerMigration('ckan_resource_base');
+  Migration::registerMigration('datajson_dataset_base');
+}
+
+/**
  * Creates resource list from CKAN site.
  *
  * CKAN has no resource_list endpiont. This function creates a file that mimics


### PR DESCRIPTION
Ref: https://github.com/NuCivic/healthdata/issues/518

Acceptance:
- [x] Disable and then re-enable the module.  The modfied column should be present in the following migration table:

![2015-10-12_19-54-53](https://cloud.githubusercontent.com/assets/444215/10441843/3eae86dc-711b-11e5-8103-83f1b8e78a0e.png)
