### PR TITLE
Fix issue with downloadURL not used after harvest

### DIFF
--- a/dkan_migrate_base.migrate.inc
+++ b/dkan_migrate_base.migrate.inc
@@ -438,7 +438,7 @@ abstract class MigrateDKAN extends Migration {
       if (!$file) {
         $req = drupal_http_request($res->url, array('timeout' => 5));
         if ($req->code == 200) {
-          $mime = substr($req->headers['content-type'], 0, strpos($req->headers['content-type'], ";"));
+          $mime = explode(";", $req->headers['content-type'])[0];
           if ($type = recline_get_data_type($mime)) {
             $link_field = field_info_instance('node', 'field_link_remote_file', 'resource');
             $ext = explode(' ', $link_field['settings']['file_extensions']);


### PR DESCRIPTION
After some research I've tracked down the downloadURL issue to the
dkan_migrate_base.migrate.inc.

There is a line to extract the mime type from the content type header but
when parse that string it uses strpos to look for the ; that sometimes appears
in the content type string. However strpos may return FALSE if semi colon is not
present. This result it's passed to the substr function which cast that to 0 and
then it retrieves an emtpy string and that's blocks all the file import.

As result remote files are not set as file urls but file api types.
