### PR TITLE
Add url guess mime type

### DIFF
--- a/dkan_migrate_base_data_json.inc
+++ b/dkan_migrate_base_data_json.inc
@@ -13,7 +13,6 @@ class MigrateDataJsonDatasetBase extends MigrateDKAN {
    * Here we go.
    */
   public function __construct($arguments) {
-
     parent::__construct($arguments);
     $this->endpoint = isset($arguments['endpoint']) ? $arguments['endpoint'] : dirname(__FILE__) . '/modules/dkan_migrate_base_example/data/data11.json';
     $this->version = isset($arguments['version']) ? $arguments['version'] : '1.1';
@@ -300,6 +299,8 @@ class MigrateDataJsonDatasetBase extends MigrateDKAN {
     $row->resources = $this->prepareResources($row);
     $this->prepareAdditionalInfo($row);
     $row->uid = 1;
+    $row->accrualPeriodicity = dkan_dataset_content_types_iso2frequency($row->accrualPeriodicity);
+
   }
 
   /**
@@ -515,6 +516,7 @@ class MigrateDataJsonDatasetBase extends MigrateDKAN {
    * Implements prepareRow.
    */
   public function prepare($entity, $row) {
+    
     // Remove empy additional fields.
     if (isset($entity->field_additional_info['und'][0]) && $entity->field_additional_info['und'][0]['first'] == NULL) {
       unset($entity->field_additional_info);

--- a/dkan_migrate_base_data_json.inc
+++ b/dkan_migrate_base_data_json.inc
@@ -423,11 +423,22 @@ class MigrateDataJsonDatasetBase extends MigrateDKAN {
           $res->format = str_replace('application/', '', $resource['mediaType']);
         }
         $res->name = isset($resource['title']) ? $resource['title'] : '';
+
+        // When no format is provided then we try to guess it from
+        // the remote resource.
+        if(empty($res->format) && isset($resource['downloadURL'])) {
+          $url = $resource['downloadURL'];
+          $is_valid_url = !empty($url) && filter_var($url, FILTER_VALIDATE_URL);
+          $res->format = ($is_valid_url) ? $this->getRemoteMime($url) : '';
+          $res->format = recline_get_data_type($res->format);
+        }
+
         // Provide default for distribution items with absent name property.
         if ($res->format && !$res->name) {
           $res->name = $res->format;
         }
         $res->name = $res->name ? $res->name : t('Resource');
+
         $res->url = $resource['downloadURL'];
         $res->api = $resource['accessURL'];
         $resource_node = $this->createResourceNode($res);
@@ -437,6 +448,23 @@ class MigrateDataJsonDatasetBase extends MigrateDKAN {
       }
     }
     return $resources;
+  }
+
+  // We should pull out this from here to another
+  // more generic module. Thus we can reuse this
+  // function in several places.
+  public function getRemoteMime($url) {
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_URL, $url);
+    curl_setopt($curl, CURLOPT_FILETIME, true);
+    curl_setopt($curl, CURLOPT_NOBODY, true);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($curl, CURLOPT_HEADER, true);
+    $header = curl_exec($curl);
+    $info = curl_getinfo($curl);
+    curl_close($curl);
+    $mime = explode(";", $info['content_type'])[0];
+    return strtolower($mime);
   }
 
   /**

--- a/modules/dkan_migrate_base_example/data/data1.json
+++ b/modules/dkan_migrate_base_example/data/data1.json
@@ -1,1 +1,79 @@
-[{"title":"Data Catalog","description":"Version 1.0","keyword":["catalog"],"modified":"2014-06-24","publisher":"NuData Sandbox","contactPoint":"NuData Sandbox","mbox":"federica@nucivic.com","identifier":"1","accessLevel":"public","distribution":[{"accessURL":"http:\/\/nudatasandbox.local\/data.json","format":"application\/json"}]},{"title":"Gross Rent over time","description":"","keyword":["rent","housing"],"modified":"2014-06-24","publisher":"Housing","contactPoint":"","mbox":"","identifier":"b6a4942e-fa73-4cbf-804f-1f9eea6d02df","accessLevel":"public","accessURL":"http:\/\/nudatasandbox.local\/dataset\/gross-rent-over-time","webService":"http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=b6a4942e-fa73-4cbf-804f-1f9eea6d02df","distribution":[{"accessURL":"http:\/\/nudatasandbox.local\/sites\/default\/files\/grossrents_adj.txt","size":4356,"format":"text\/plain"},{"accessURL":"http:\/\/nudatasandbox.local\/sites\/default\/files\/grossrents_adj.csv","size":4526,"format":"text\/csv"}],"license":"License Not Specified","language":["english"],"granularity":""},{"title":"Hospital Compare","description":"The data that is used by the Hospital Compare tool can be downloaded for public use. This functionality is primarily used by health policy researchers and the media. The data provided includes process of care, mortality, and readmission quality measures. The collection period for the measures is generally 12 months. However, some measures may be based upon fewer than 12 months. Generally, the Hospital Compare quality measures are refreshed the third month of each quarter.","keyword":["health","hospitals","community"],"modified":"2014-06-24","publisher":"Health","contactPoint":"","mbox":"","identifier":"2be7feb9-150f-4b7b-ac73-c9f337fc9341","accessLevel":"public","accessURL":"http:\/\/nudatasandbox.local\/dataset\/hospital-compare","webService":"http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=2be7feb9-150f-4b7b-ac73-c9f337fc9341","distribution":[{"accessURL":"http:\/\/nudatasandbox.local\/sites\/default\/files\/HQI_HOSP_AHRQ_NATIONAL.csv","size":4068,"format":"text\/csv"}],"license":"Open Data Commons Attribution License","language":["english"],"granularity":""},{"title":"NGA Scores","description":"","keyword":[],"modified":"2014-06-23","publisher":"","contactPoint":"","mbox":"","identifier":"765bc983-a4f5-438a-bf3c-6e171c7cc15a","accessLevel":"public","accessURL":"http:\/\/nudatasandbox.local\/dataset\/nga-scores","webService":"http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=765bc983-a4f5-438a-bf3c-6e171c7cc15a","distribution":[{"accessURL":"http:\/\/nudatasandbox.local\/sites\/default\/files\/values.csv","size":57836,"format":"text\/csv"}],"license":"Creative Commons Attribution","language":["english"],"granularity":""}]
+[{
+  "title": "Data Catalog",
+  "description": "Version 1.0",
+  "keyword": ["catalog"],
+  "modified": "2014-06-24",
+  "publisher": "NuData Sandbox",
+  "contactPoint": "NuData Sandbox",
+  "mbox": "federica@nucivic.com",
+  "identifier": "1",
+  "accessLevel": "public",
+  "distribution": [{
+    "accessURL": "http:\/\/nudatasandbox.local\/data.json",
+    "format": "application\/json"
+  }]
+}, {
+  "title": "Gross Rent over time",
+  "description": "",
+  "keyword": ["rent", "housing"],
+  "modified": "2014-06-24",
+  "publisher": "Housing",
+  "contactPoint": "",
+  "mbox": "",
+  "identifier": "b6a4942e-fa73-4cbf-804f-1f9eea6d02df",
+  "accessLevel": "public",
+  "accessURL": "http:\/\/nudatasandbox.local\/dataset\/gross-rent-over-time",
+  "webService": "http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=b6a4942e-fa73-4cbf-804f-1f9eea6d02df",
+  "distribution": [{
+    "accessURL": "http:\/\/nudatasandbox.local\/sites\/default\/files\/grossrents_adj.txt",
+    "size": 4356,
+    "format": "text\/plain"
+  }, {
+    "accessURL": "http:\/\/nudatasandbox.local\/sites\/default\/files\/grossrents_adj.csv",
+    "size": 4526,
+    "format": "text\/csv"
+  }],
+  "license": "License Not Specified",
+  "language": ["english"],
+  "granularity": ""
+}, {
+  "title": "Hospital Compare",
+  "description": "The data that is used by the Hospital Compare tool can be downloaded for public use. This functionality is primarily used by health policy researchers and the media. The data provided includes process of care, mortality, and readmission quality measures. The collection period for the measures is generally 12 months. However, some measures may be based upon fewer than 12 months. Generally, the Hospital Compare quality measures are refreshed the third month of each quarter.",
+  "keyword": ["health", "hospitals", "community"],
+  "modified": "2014-06-24",
+  "publisher": "Health",
+  "contactPoint": "",
+  "mbox": "",
+  "identifier": "2be7feb9-150f-4b7b-ac73-c9f337fc9341",
+  "accessLevel": "public",
+  "accessURL": "http:\/\/nudatasandbox.local\/dataset\/hospital-compare",
+  "webService": "http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=2be7feb9-150f-4b7b-ac73-c9f337fc9341",
+  "distribution": [{
+    "accessURL": "http:\/\/nudatasandbox.local\/sites\/default\/files\/HQI_HOSP_AHRQ_NATIONAL.csv",
+    "size": 4068,
+    "format": "text\/csv"
+  }],
+  "license": "Open Data Commons Attribution License",
+  "language": ["english"],
+  "granularity": ""
+}, {
+  "title": "NGA Scores",
+  "description": "",
+  "keyword": [],
+  "modified": "2014-06-23",
+  "publisher": "",
+  "contactPoint": "",
+  "mbox": "",
+  "identifier": "765bc983-a4f5-438a-bf3c-6e171c7cc15a",
+  "accessLevel": "public",
+  "accessURL": "http:\/\/nudatasandbox.local\/dataset\/nga-scores",
+  "webService": "http:\/\/nudatasandbox.local\/api\/3\/action\/package_show?id=765bc983-a4f5-438a-bf3c-6e171c7cc15a",
+  "distribution": [{
+    "accessURL": "http:\/\/nudatasandbox.local\/sites\/default\/files\/values.csv",
+    "size": 57836,
+    "format": "text\/csv"
+  }],
+  "license": "Creative Commons Attribution",
+  "language": ["english"],
+  "granularity": ""
+}]

--- a/modules/dkan_migrate_base_example/data/data11.json
+++ b/modules/dkan_migrate_base_example/data/data11.json
@@ -23,9 +23,8 @@
                 },
                 {
                     "@type": "dcat:Distribution",
-                    "downloadURL": "http://example.com/sites/default/files/grossrents_adj.csv",
-                    "mediaType": "text/csv",
-                    "format": "csv",
+                    "accessURL": "http://demo.getdkan.com/dataset/wisconsin-polling-places",
+                    "downloadURL": "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv",
                     "description": "No description provided"
                 }
             ],

--- a/tests/DKANMigrateBaseTest.php
+++ b/tests/DKANMigrateBaseTest.php
@@ -80,6 +80,7 @@ class DKANMigrateBaseTest  extends PHPUnit_Framework_TestCase
       dkan_migrate_base_add_modified_column($table);
 
       $result = $migration->processImport();
+
       $this->assertNotEquals($result, Migration::RESULT_FAILED);
       $this->assertEquals(0, $migration->errorCount());
     }
@@ -205,7 +206,7 @@ class DKANMigrateBaseTest  extends PHPUnit_Framework_TestCase
       $result['temporalEnd']  = $node->field_temporal_coverage['und'][0]['value2'];
       $expect['temporalEnd']  = "2010-01-15 00:06:00";
       $result['accrualPeriodicity']  = $node->field_frequency['und'][0]['value'];
-      $expect['accrualPeriodicity']  = "R/P1Y";
+      $expect['accrualPeriodicity']  = 3;
       $result['describedBy']  = $node->field_data_dictionary['und'][0]['value'];
       $expect['describedBy']  = "http://www.agency.gov/vegetables/definitions.pdf";
       $result['references']  = $node->field_related_content['und'][0]['url'];

--- a/tests/DKANMigrateBaseTest.php
+++ b/tests/DKANMigrateBaseTest.php
@@ -227,9 +227,10 @@ class DKANMigrateBaseTest  extends PHPUnit_Framework_TestCase
       $expect['resource2Name']  = "csv";
       $result['resource2Format']  = $format2->name;
       $expect['resource2Format']  = "csv";
-      $result['resource2DownloadUrl']  = $resource2->field_link_api['und'][0]['url'];
-      $expect['resource2DownloadUrl']  = "http://example.com/sites/default/files/grossrents_adj.csv";
-
+      $result['resource2DownloadUrl']  = $resource2->field_link_remote_file['und'][0]['uri'];
+      $expect['resource2DownloadUrl']  = "http://demo.getdkan.com/sites/default/files/Polling_Places_Madison_0.csv";
+      $result['resource2AccessUrl']  = $resource2->field_link_api['und'][0]['url'];
+      $expect['resource2AccessUrl']  = "http://demo.getdkan.com/dataset/wisconsin-polling-places";
       // TODO:
       // maintainer
       // maintainer_email


### PR DESCRIPTION
When downloadURL and accessURL are present make no sense to have a format defined.

However if a format it's specified it would be used. When no format is specified 
and there is a downloadURL set then it tries to guess the format from that file.
This is what this PR adds.
### PR Dependencies

https://github.com/NuCivic/dkan_dataset/pull/241
